### PR TITLE
WF-35 ⁃ Update styles.php

### DIFF
--- a/code/wright/parameters/joomla_2.5/styles.php
+++ b/code/wright/parameters/joomla_2.5/styles.php
@@ -22,7 +22,7 @@ class JFormFieldStyles extends JFormFieldList
 		$styles = JFolder::files(JPATH_ROOT.'/templates'.'/'.$this->form->getValue('template').'/css', 'style-([^\.]*)\.css');
 
         if (!count($styles)) {
-	        return array(JHTML::_('select.option', '', JText::_('No styles are provided for this template'), true));
+	        return array(JHTML::_('select.option', '', JText::_('No styles are provided for this template')));
         }
 
 		foreach ($styles as $style)


### PR DESCRIPTION
the fourth parameter of the JHTML::_('select.option',... ) is not anymore valid because it is responsible of a "PHP notice" when we browse template options page in joomla 3.x control panel.

In fact the line :

```
return array(JHTML::_('select.option', '', JText::_('No styles are provided for this template'), true));
```

call the option method of the ""Joomla_PATH"" \libraries\cms\html\select.php file
and pass the "true" parameter to it, but the "true" parameter does not match the method signature which has "now" 5 parameters

The call should be : 

```
return array(JHTML::_('select.option', '', JText::_('No styles are provided for this template'), 'value', 'text', true)); 
```

OR

```
return array(JHTML::_('select.option', '', JText::_('No styles are provided for this template'), 'value', 'text', false)); 
```

Because the last parameter is the "disable" one, and is not used by the "option" method ( according to method comments )
SO .... we can fix that line with : 

```
return array(JHTML::_('select.option', '', JText::_('No styles are provided for this template')));
```

because we use the default parameters value of the "option" method. 

:)