### PR TITLE
WF-54 ⁃ Use new way of getting Joomla Version information

### DIFF
--- a/code/wright/html/overrider.php
+++ b/code/wright/html/overrider.php
@@ -19,8 +19,15 @@ class Overrider
 	{
 		if (!isset(self::$version)) {
 			jimport('joomla.version');
-			$version = new JVersion();
-			self::$version = explode('.', $version->RELEASE);
+			if (defined('JVersion::RELEASE'))
+			{
+				self::$version = explode('.', JVersion::RELEASE);
+			}
+			else
+			{
+				$version = new JVersion();
+				self::$version = explode('.', $version->RELEASE);
+			}
 		}
 
 		return self::$version;

--- a/code/wright/wright.php
+++ b/code/wright/wright.php
@@ -544,8 +544,15 @@ class Wright
 	{
 		// Get Joomla's version to get proper platform
 		jimport('joomla.version');
-		$version = new JVersion;
-		$file = ucfirst(str_replace('.', '', $version->RELEASE));
+		if (defined('JVersion::RELEASE'))
+		{
+			$file = ucfirst(str_replace('.', '', JVersion::RELEASE));
+		}
+		else
+		{
+			$version = new JVersion;
+			$file = ucfirst(str_replace('.', '', $version->RELEASE));
+		}
 
 		// Load up the proper adapter
 		require_once dirname(__FILE__) . '/adapters/joomla.php';


### PR DESCRIPTION
Since 3.5 JVersion has used class constants https://github.com/joomla/joomla-cms/pull/7217 (with a b/c layer for the rest of the 3.x series). This uses the class constants when they are available, for compatibility with the J4 series where you must use the class constants