### PR TITLE
WF-59 ⁃ Fixes search result highlighting

### DIFF
--- a/code/wright/html/joomla_3.0/com_search/search/default_results.php
+++ b/code/wright/html/joomla_3.0/com_search/search/default_results.php
@@ -17,10 +17,10 @@ defined('_JEXEC') or die;
 		<?php echo $this->pagination->limitstart + $result->count.'. ';?>
 		<?php if ($result->href) :?>
 			<a href="<?php echo JRoute::_($result->href); ?>"<?php if ($result->browsernav == 1) :?> target="_blank"<?php endif;?>>
-				<?php echo $this->escape($result->title);?>
+				<?php echo $result->title;?>
 			</a>
 		<?php else:?>
-			<?php echo $this->escape($result->title);?>
+			<?php echo $result->title;?>
 		<?php endif; ?>
 	</dt>
 	<?php if ($result->section) : ?>


### PR DESCRIPTION
Due to https://github.com/joomla/joomla-cms/pull/16484/files , search results titles that have a search keyword now display as:
`<span class="highlight">Sample</span> title...`

Instead of:
`Same Title`

This fixes it.

If needed, more info about this issue is found at https://github.com/joomla/joomla-cms/issues/16979